### PR TITLE
商品購入機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,27 @@
 class ItemsController < ApplicationController
+  before_action :find_item, only: :order
   def index
     @items = Item.all
+  end
+
+  def order
+    # カードが未登録であればまずはカード登録から行う
+    redirect_to new_card_path and return unless current_user.card.present?
+
+    Payjp.api_key = ENV['PAYJP_SECRET_KEY'] # 環境変数を読み込む
+    customer_token = current_user.card.customer_token # ログインしているユーザーの顧客トークンを定義
+    Payjp::Charge.create(
+      amount: @item.price, # 商品の値段
+      customer: customer_token, # 顧客のトークン
+      currency: 'jpy' # 通貨の種類（日本円）
+    )
+    ItemOrder.create(item_id: params[:id]) # 商品のid情報を「item_id」として保存する
+    redirect_to root_path
+  end
+
+  private
+
+  def find_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,3 @@
 class Item < ApplicationRecord
+  has_one :item_order
 end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,0 +1,2 @@
+class ItemOrder < ApplicationRecord
+end

--- a/app/models/item_order.rb
+++ b/app/models/item_order.rb
@@ -1,2 +1,3 @@
 class ItemOrder < ApplicationRecord
+  belongs_to :item
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,6 +4,6 @@
   <% @items.each do |item| %>
     <p>商品名：<%= item.name %></p>
     <p>値段：<%= item.price %>円</p>
-    <%= link_to '購入する'%>
+    <%= link_to '購入する', order_item_path(item.id), method: :post %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
-  get 'cards/new'
-  get 'users/show'
-  get 'items/index'
   devise_for :users
   root 'items#index'
   resources :users, only: [:show, :update]
   resources :cards, only: [:new, :create]
+  resources :items, only: :order do
+    post 'order', on: :member
+  end
 end

--- a/db/migrate/20210127133738_create_item_orders.rb
+++ b/db/migrate/20210127133738_create_item_orders.rb
@@ -1,0 +1,8 @@
+class CreateItemOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :item_orders do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210127133738_create_item_orders.rb
+++ b/db/migrate/20210127133738_create_item_orders.rb
@@ -1,6 +1,7 @@
 class CreateItemOrders < ActiveRecord::Migration[6.0]
   def change
     create_table :item_orders do |t|
+      t.references :item, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_11_083909) do
+ActiveRecord::Schema.define(version: 2021_01_27_133738) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "card_token", null: false
@@ -19,6 +19,13 @@ ActiveRecord::Schema.define(version: 2021_01_11_083909) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_cards_on_user_id"
+  end
+
+  create_table "item_orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_item_orders_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -42,4 +49,5 @@ ActiveRecord::Schema.define(version: 2021_01_11_083909) do
   end
 
   add_foreign_key "cards", "users"
+  add_foreign_key "item_orders", "items"
 end

--- a/spec/factories/item_orders.rb
+++ b/spec/factories/item_orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_order do
+    
+  end
+end

--- a/spec/factories/item_orders.rb
+++ b/spec/factories/item_orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :item_order do
-    
   end
 end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemOrder, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Closes #5 

# What
- 購入情報のみのitem_orderモデルを作成する。
- 購入情報はitemに紐づくため、memberを使ってルーティングを設定。
- itemコントローラーにPayjpの「Chargeオブジェクト」を使用し、支払情報を送る実装をする。

# Why
- 購入にあたり、環境変数や支払情報をPayjpに送付する必要があるため。
- 購入した商品か否か、データベースに情報を保存したいため。